### PR TITLE
fix: search delegate app bar theme

### DIFF
--- a/change/tfl-api-explorer-2019-09-07-15-56-27-fix-search-delegate-app-bar-theme.json
+++ b/change/tfl-api-explorer-2019-09-07-15-56-27-fix-search-delegate-app-bar-theme.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix bike point search app bar theme.",
+  "packageName": "tfl_api_explorer",
+  "email": "tnc1997@virginmedia.com",
+  "commit": "4a603a983b8386b4b3e3ca4e8dde08e1c51189c9",
+  "date": "2019-09-07T14:56:27.942Z"
+}

--- a/lib/delegates/bike_point_search_delegate.dart
+++ b/lib/delegates/bike_point_search_delegate.dart
@@ -10,6 +10,28 @@ class BikePointSearchDelegate extends SearchDelegate<Place> {
   BikePointSearchDelegate(this._bikePoints);
 
   @override
+  ThemeData appBarTheme(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return theme.copyWith(
+      inputDecorationTheme: InputDecorationTheme(
+        hintStyle: TextStyle(
+          color: theme.primaryTextTheme.title.color,
+        ),
+      ),
+      primaryColor: theme.primaryColor,
+      primaryIconTheme: theme.primaryIconTheme,
+      primaryColorBrightness: theme.primaryColorBrightness,
+      primaryTextTheme: theme.primaryTextTheme,
+      textTheme: theme.textTheme.copyWith(
+        title: theme.textTheme.title.copyWith(
+          color: theme.primaryTextTheme.title.color,
+        ),
+      ),
+    );
+  }
+
+  @override
   List<Widget> buildActions(BuildContext context) {
     return <Widget>[
       IconButton(


### PR DESCRIPTION
## Pull Request Checklist
<!-- Check if your pull request fulfills the requirements. -->
- [x] Commit Message Follows Guidelines
- [ ] Tests For Changes Have Been Added
- [ ] Docs Have Been Added Or Updated

## Current Behaviour
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The bike point search delegate currently uses the default app bar theme.

## New Behaviour
<!-- Please describe the new behavior that you have implemented. -->
The bike point search delegate now uses the app's theme for the app bar.